### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ I do not recommend compiling the agent and using it for operations. Agent compil
 - IOC: `%LOCALAPPDATA%\Microsoft\Teams\current\app` directory created
 - IOC: `%LOCALAPPDATA%\Microsoft\Teams\current\app.asar` file created/modified by non-Teams installer/updater
 - [SIGMA rule](https://github.com/4y45u45c4/SIGMA/blob/main/loki_c2_channel_established_from_electron_app.yaml) to detect established Loki C2 from electron app
+- [SIGMA rule](https://github.com/4y45u45c4/SIGMA/blob/main/hijack_of_electron_app_to_load_C2_framework.yaml) to detect hijacking of Electron's app folder (Teams, VS Code, RingCentral, Postman) to load C2 framework 
 
 
 # References || Acknowledgements || Offensive Electron Research 


### PR DESCRIPTION
Added sigma to detect hijack of Electron's app folder to load C2 framework.
Written originally for S1 EDR. Includes Teams, and 3 electrons where I established Loki C2 comms: VS Code, RingCentral, Postman. Rule triggered for them, and with applied exclusions no FPs in envi with thousands of endpoints running these apps. 