### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ First you need to identify a vulnerable Electron application which does not do A
 | ✅         | [Franz](https://meetfranz.com/)                       | `Franz.exe`         | `5.11.0`        | [pir4cy](https://github.com/pir4cy)                                            |
 | ✅         | [TIDAL](https://tidal.com/)                           | `TIDAL.exe`         |                 | [pir4cy](https://github.com/pir4cy)                                            |
 | ✅         | [FACEIT](https://faceit.com/)                          | `FACEIT.exe`         | `2.1.10`                | [icheernoom](https://x.com/icheernoom)                               |
+| ✅         | [Unity](https://unity.com/)                          | `Unity Hub.exe`       |                | [Sawyer](https://github.com/SawyersPresent)                                |
 | ❌         | 1Password                                             | `1Password.exe`     |                 |                                                                              |
 | ❌         | Signal                                                | `Signal.exe`        |                 |                                                                              |
 | ❌         | Slack                                                 | `slack.exe`         |                 |                                                                              |


### PR DESCRIPTION
Unity Hub.exe is vulnerable to Loki C2, Latest version.

![image](https://github.com/user-attachments/assets/8c808914-efd2-4184-9327-2a552d6dc087)
